### PR TITLE
Fixed NPE

### DIFF
--- a/editorconfig-eclipse-plugin/src/main/java/com/ncjones/editorconfig/eclipse/EditorConfigEditorActivationHandler.java
+++ b/editorconfig-eclipse-plugin/src/main/java/com/ncjones/editorconfig/eclipse/EditorConfigEditorActivationHandler.java
@@ -38,10 +38,12 @@ public class EditorConfigEditorActivationHandler implements EditorActivationHand
 
 	@Override
 	public void editorActivated(final IFile editorFile) {
-		final EditorFileConfig fileEditorConfig = getEditorFileConfig(editorFile);
-		System.out.println("Editor activated: " + fileEditorConfig);
-		for (final ConfigProperty<?> configProperty : fileEditorConfig.getConfigProperties()) {
-			configProperty.accept(this);
+		if (editorFile != null) {
+			final EditorFileConfig fileEditorConfig = getEditorFileConfig(editorFile);
+			System.out.println("Editor activated: " + fileEditorConfig);
+			for (final ConfigProperty<?> configProperty : fileEditorConfig.getConfigProperties()) {
+				configProperty.accept(this);
+			}
 		}
 	}
 


### PR DESCRIPTION
I'm not sure exactly what caused them, I think it's looking at library source files, but eclipse was littered with the following exceptions...

```
!ENTRY org.eclipse.e4.ui.workbench 4 0 2015-08-03 10:12:57.061
!MESSAGE 
!STACK 0
java.lang.NullPointerException
    at com.ncjones.editorconfig.eclipse.EditorConfigEditorActivationHandler.getEditorFileConfig(EditorConfigEditorActivationHandler.java:49)
    at com.ncjones.editorconfig.eclipse.EditorConfigEditorActivationHandler.editorActivated(EditorConfigEditorActivationHandler.java:41)
    at com.ncjones.editorconfig.eclipse.EditorActivationSelectionListener.selectionChanged(EditorActivationSelectionListener.java:41)
    at org.eclipse.ui.internal.e4.compatibility.SelectionService.notifyListeners(SelectionService.java:237)
    at org.eclipse.ui.internal.e4.compatibility.SelectionService.handleSelectionChanged(SelectionService.java:107)
    at org.eclipse.ui.internal.e4.compatibility.SelectionService.access$0(SelectionService.java:91)
    at org.eclipse.ui.internal.e4.compatibility.SelectionService$1.selectionChanged(SelectionService.java:66)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator$2.run(SelectionAggregator.java:126)
    at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.notifyListeners(SelectionAggregator.java:123)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.access$6(SelectionAggregator.java:120)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator$7$1.run(SelectionAggregator.java:233)
    at org.eclipse.e4.core.contexts.RunAndTrack.runExternalCode(RunAndTrack.java:56)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator$7.changed(SelectionAggregator.java:230)
    at org.eclipse.e4.core.internal.contexts.TrackableComputationExt.update(TrackableComputationExt.java:114)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.runAndTrack(EclipseContext.java:322)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.track(SelectionAggregator.java:215)
    at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.setPart(SelectionAggregator.java:116)
    at sun.reflect.GeneratedMethodAccessor163.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:56)
    at org.eclipse.e4.core.internal.contexts.ContextObjectSupplier$ContextInjectionListener.update(ContextObjectSupplier.java:90)
    at org.eclipse.e4.core.internal.contexts.TrackableComputationExt.update(TrackableComputationExt.java:111)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.processScheduled(EclipseContext.java:341)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.set(EclipseContext.java:356)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.activate(EclipseContext.java:657)
    at org.eclipse.e4.core.internal.contexts.EclipseContext.activateBranch(EclipseContext.java:663)
    at org.eclipse.e4.ui.internal.workbench.PartActivationHistory.activate(PartActivationHistory.java:52)
    at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:704)
    at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:639)
    at org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer.activate(AbstractPartRenderer.java:106)
    at org.eclipse.e4.ui.workbench.renderers.swt.StackRenderer$9.widgetSelected(StackRenderer.java:1088)
    at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:248)
    at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
    at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4230)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1491)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1514)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1499)
    at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1299)
    at org.eclipse.swt.custom.CTabFolder.setSelection(CTabFolder.java:3158)
    at org.eclipse.swt.custom.CTabFolder.onMouse(CTabFolder.java:1841)
    at org.eclipse.swt.custom.CTabFolder$1.handleEvent(CTabFolder.java:330)
    at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
    at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4230)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1491)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1514)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1499)
    at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1299)
    at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4072)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3698)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
```

I simply added a a null check on the IFile object and it seems to have fixed it.
