### PR TITLE
Add capability to get properties

### DIFF
--- a/editorconfig-eclipse-functional-test/META-INF/MANIFEST.MF
+++ b/editorconfig-eclipse-functional-test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: EditorConfig Eclipse Functional Test
 Bundle-SymbolicName: editorconfig-eclipse-functional-test;singleton:=true
-Bundle-Version: 0.3.0.qualifier
+Bundle-Version: 0.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/editorconfig-eclipse-functional-test/pom.xml
+++ b/editorconfig-eclipse-functional-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.ncjones</groupId>
 		<artifactId>editorconfig-eclipse-parent</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>editorconfig-eclipse-functional-test</artifactId>

--- a/editorconfig-eclipse-functional-test/src/main/java/com/ncjones/editorconfig/eclipse/test/EditorConfigTest.java
+++ b/editorconfig-eclipse-functional-test/src/main/java/com/ncjones/editorconfig/eclipse/test/EditorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Nathan Jones
+ * Copyright 2017 Nathan Jones, Jackson Bailey
  *
  * This file is part of "EditorConfig Eclipse".
  *
@@ -65,7 +65,7 @@ public class EditorConfigTest {
 			"indent_size = 2"
 		);
 		context.editFile(fileName, "\t");
-		assertThat(context.fileContents(fileName), equalTo("  "));
+		assertThat(fileName + " has incorrect content", context.fileContents(fileName), equalTo("  "));
 	}
 
 	@Test
@@ -76,7 +76,7 @@ public class EditorConfigTest {
 			"indent_style = tab"
 		);
 		context.editFile(fileName, "\t");
-		assertThat(context.fileContents(fileName), equalTo("\t"));
+		assertThat(fileName + " has incorrect content", context.fileContents(fileName), equalTo("\t"));
 	}
 
 }

--- a/org.eclipse.editorconfig.core/src/main/java/org/eclipse/editorconfig/core/EditorFileConfig.java
+++ b/org.eclipse.editorconfig.core/src/main/java/org/eclipse/editorconfig/core/EditorFileConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Nathan Jones
+ * Copyright 2017 Nathan Jones, Jackson Bailey
  *
  * This file is part of "EditorConfig Eclipse".
  *
@@ -25,7 +25,7 @@ import java.util.Set;
 public class EditorFileConfig {
 
 	private final String path;
-	
+
 	private final Set<ConfigProperty> configProperties;
 
 	public EditorFileConfig(final String path, final Set<ConfigProperty> configProperties) {
@@ -39,6 +39,15 @@ public class EditorFileConfig {
 
 	public Set<ConfigProperty> getConfigProperties() {
 		return configProperties;
+	}
+
+	public ConfigProperty getConfigProperty(String name) {
+		for (ConfigProperty configProperty: configProperties) {
+			if (name.equals(configProperty.getType().getName())) {
+				return configProperty;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.editorconfig.core/src/test/java/org/eclipse/editorconfig/core/EditorFileConfigTest.java
+++ b/org.eclipse.editorconfig.core/src/test/java/org/eclipse/editorconfig/core/EditorFileConfigTest.java
@@ -1,0 +1,32 @@
+package org.eclipse.editorconfig.core;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.editorconfig.core.ConfigPropertyType.IndentSize;
+import org.eclipse.editorconfig.core.ConfigPropertyType.IndentStyle;
+import org.junit.Test;
+
+public class EditorFileConfigTest {
+
+	@Test
+	public void getPropertyReturnsProperty() {
+
+		final ConfigProperty<IndentStyleOption> indentStyle =
+				new ConfigProperty<IndentStyleOption>(new IndentStyle(), IndentStyleOption.TAB);
+		final ConfigProperty<Integer> indentSize = new ConfigProperty<Integer>(new IndentSize(), 2);
+
+		@SuppressWarnings("rawtypes")
+		Set<ConfigProperty> properties = new HashSet<ConfigProperty>();
+		properties.add(indentStyle);
+		properties.add(indentSize);
+
+		EditorFileConfig config = new EditorFileConfig("", properties);
+
+		assertSame(indentStyle, config.getConfigProperty("INDENT_STYLE"));
+		assertSame(indentSize, config.getConfigProperty("INDENT_SIZE"));
+		assertNull(config.getConfigProperty("TAB_WIDTH"));
+	}
+}

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigEditorActivationHandler.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigEditorActivationHandler.java
@@ -36,7 +36,7 @@ public class EditorConfigEditorActivationHandler implements EditorActivationHand
 			final EditorFileConfig fileEditorConfig = getEditorFileConfig(editorFile);
 			System.out.println("Editor activated: " + fileEditorConfig);
 			for (final ConfigProperty<?> configProperty : fileEditorConfig.getConfigProperties()) {
-				configProperty.accept(new EditorConfigVisitor());
+				configProperty.accept(new EditorConfigVisitor(fileEditorConfig));
 			}
 		}
 	}

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigEditorActivationHandler.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigEditorActivationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Nathan Jones
+ * Copyright 2017 Nathan Jones, Jackson Bailey
  *
  * This file is part of "EditorConfig Eclipse".
  *
@@ -18,16 +18,11 @@
 package org.eclipse.editorconfig.ui.internal;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.editorconfig.core.ConfigProperty;
-import org.eclipse.editorconfig.core.ConfigPropertyVisitor;
 import org.eclipse.editorconfig.core.EditorConfigService;
 import org.eclipse.editorconfig.core.EditorFileConfig;
-import org.eclipse.editorconfig.core.EndOfLineOption;
-import org.eclipse.editorconfig.core.IndentStyleOption;
 
-public class EditorConfigEditorActivationHandler implements EditorActivationHandler, ConfigPropertyVisitor {
+public class EditorConfigEditorActivationHandler implements EditorActivationHandler {
 
 	private final EditorConfigService editorConfigService;
 
@@ -41,7 +36,7 @@ public class EditorConfigEditorActivationHandler implements EditorActivationHand
 			final EditorFileConfig fileEditorConfig = getEditorFileConfig(editorFile);
 			System.out.println("Editor activated: " + fileEditorConfig);
 			for (final ConfigProperty<?> configProperty : fileEditorConfig.getConfigProperties()) {
-				configProperty.accept(this);
+				configProperty.accept(new EditorConfigVisitor());
 			}
 		}
 	}
@@ -49,55 +44,6 @@ public class EditorConfigEditorActivationHandler implements EditorActivationHand
 	private EditorFileConfig getEditorFileConfig(final IFile file) {
 		final String path = file.getLocation().toString();
 		return editorConfigService.getEditorConfig(path);
-	}
-
-	private void setPreference(final String prefsNodeName, final String key, final String value) {
-		System.out.println(String.format("Setting preference: %s/%s=%s", prefsNodeName, key, value));
-		final IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(prefsNodeName);
-		prefs.put(key, value);
-	}
-
-	@Override
-	public void visitIndentStyle(final ConfigProperty<IndentStyleOption> property) {
-		final Boolean spacesForTabs = property.getValue().equals(IndentStyleOption.SPACE);
-		setPreference("org.eclipse.ui.editors", "spacesForTabs", spacesForTabs.toString());
-		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.char", spacesForTabs ? "space" : "tab");
-		setPreference("org.eclipse.wst.xml.core", "indentationChar", spacesForTabs ? "space" : "tab");
-		setPreference("org.eclipse.ant.ui", "formatter_tab_char", Boolean.toString(!spacesForTabs));
-	}
-
-	@Override
-	public void visitIndentSize(final ConfigProperty<Integer> property) {
-		final String indentSizeString = property.getValue().toString();
-		setPreference("org.eclipse.ui.editors", "tabWidth", indentSizeString);
-		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", indentSizeString);
-		setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
-		setPreference("org.eclipse.ant.ui", "formatter_tab_size", indentSizeString);
-	}
-
-	@Override
-	public void visitTabWidth(final ConfigProperty<Integer> property) {
-	}
-
-	@Override
-	public void visitEndOfLine(final ConfigProperty<EndOfLineOption> property) {
-		setPreference("org.eclipse.core.runtime", "line.separator", property.getValue().getEndOfLineString());
-	}
-
-	@Override
-	public void visitCharset(final ConfigProperty<String> property) {
-		setPreference("org.eclipse.core.resources", "encoding", property.getValue().toUpperCase());
-	}
-
-	@Override
-	public void visitTrimTrailingWhitespace(final ConfigProperty<Boolean> property) {
-		setPreference("org.eclipse.jdt.ui", "sp_cleanup.remove_trailing_whitespaces", property.getValue().toString());
-	}
-
-	@Override
-	public void visitInsertFinalNewLine(final ConfigProperty<Boolean> property) {
-		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing",
-				property.getValue().toString());
 	}
 
 }

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -21,10 +21,17 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.editorconfig.core.ConfigProperty;
 import org.eclipse.editorconfig.core.ConfigPropertyVisitor;
+import org.eclipse.editorconfig.core.EditorFileConfig;
 import org.eclipse.editorconfig.core.EndOfLineOption;
 import org.eclipse.editorconfig.core.IndentStyleOption;
 
 public class EditorConfigVisitor implements ConfigPropertyVisitor {
+
+	private final EditorFileConfig editorFileConfig;
+
+	public EditorConfigVisitor(EditorFileConfig editorFileConfig) {
+		this.editorFileConfig = editorFileConfig;
+	}
 
 	private void setPreference(final String prefsNodeName, final String key, final String value) {
 		System.out.println(String.format("Setting preference: %s/%s=%s", prefsNodeName, key, value));

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -39,22 +39,36 @@ public class EditorConfigVisitor implements ConfigPropertyVisitor {
 		prefs.put(key, value);
 	}
 
+	private void clearPreference(final String prefsNodeName, final String key) {
+		System.out.println(String.format("Clearing preference: %s/%s", prefsNodeName, key));
+		final IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(prefsNodeName);
+		prefs.remove(key);
+	}
+
 	@Override
 	public void visitIndentStyle(final ConfigProperty<IndentStyleOption> property) {
 		final Boolean spacesForTabs = property.getValue().equals(IndentStyleOption.SPACE);
 		setPreference("org.eclipse.ui.editors", "spacesForTabs", spacesForTabs.toString());
 		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.char", spacesForTabs ? "space" : "tab");
-		setPreference("org.eclipse.wst.xml.core", "indentationChar", spacesForTabs ? "space" : "tab");
 		setPreference("org.eclipse.ant.ui", "formatter_tab_char", Boolean.toString(!spacesForTabs));
 	}
 
 	@Override
 	public void visitIndentSize(final ConfigProperty<Integer> property) {
 		final String indentSizeString = property.getValue().toString();
+		final Object indentStyle = editorFileConfig.getConfigProperty("INDENT_STYLE").getValue();
+
 		setPreference("org.eclipse.ui.editors", "tabWidth", indentSizeString);
 		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", indentSizeString);
-		setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
 		setPreference("org.eclipse.ant.ui", "formatter_tab_size", indentSizeString);
+
+		if (IndentStyleOption.TAB.equals(indentStyle)) {
+			setPreference("org.eclipse.wst.xml.core", "indentationChar", "tab");
+			clearPreference("org.eclipse.wst.xml.core", "indentationSize");
+		} else if (IndentStyleOption.SPACE.equals(indentStyle)) {
+			setPreference("org.eclipse.wst.xml.core", "indentationChar", "space");
+			setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
+		}
 	}
 
 	@Override

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -56,7 +56,12 @@ public class EditorConfigVisitor implements ConfigPropertyVisitor {
 	@Override
 	public void visitIndentSize(final ConfigProperty<Integer> property) {
 		final String indentSizeString = property.getValue().toString();
-		final Object indentStyle = editorFileConfig.getConfigProperty("INDENT_STYLE").getValue();
+
+		final ConfigProperty indentStyleProperty = editorFileConfig.getConfigProperty("INDENT_STYLE");
+		Object indentStyle = null;
+		if (indentStyleProperty != null) {
+			indentStyle = indentStyleProperty.getValue();
+		}
 
 		setPreference("org.eclipse.ui.editors", "tabWidth", indentSizeString);
 		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", indentSizeString);

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Nathan Jones, Jackson Bailey
+ *
+ * This file is part of "EditorConfig Eclipse".
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.editorconfig.ui.internal;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.editorconfig.core.ConfigProperty;
+import org.eclipse.editorconfig.core.ConfigPropertyVisitor;
+import org.eclipse.editorconfig.core.EndOfLineOption;
+import org.eclipse.editorconfig.core.IndentStyleOption;
+
+public class EditorConfigVisitor implements ConfigPropertyVisitor {
+
+	private void setPreference(final String prefsNodeName, final String key, final String value) {
+		System.out.println(String.format("Setting preference: %s/%s=%s", prefsNodeName, key, value));
+		final IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(prefsNodeName);
+		prefs.put(key, value);
+	}
+
+	@Override
+	public void visitIndentStyle(final ConfigProperty<IndentStyleOption> property) {
+		final Boolean spacesForTabs = property.getValue().equals(IndentStyleOption.SPACE);
+		setPreference("org.eclipse.ui.editors", "spacesForTabs", spacesForTabs.toString());
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.char", spacesForTabs ? "space" : "tab");
+		setPreference("org.eclipse.wst.xml.core", "indentationChar", spacesForTabs ? "space" : "tab");
+		setPreference("org.eclipse.ant.ui", "formatter_tab_char", Boolean.toString(!spacesForTabs));
+	}
+
+	@Override
+	public void visitIndentSize(final ConfigProperty<Integer> property) {
+		final String indentSizeString = property.getValue().toString();
+		setPreference("org.eclipse.ui.editors", "tabWidth", indentSizeString);
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", indentSizeString);
+		setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
+		setPreference("org.eclipse.ant.ui", "formatter_tab_size", indentSizeString);
+	}
+
+	@Override
+	public void visitTabWidth(final ConfigProperty<Integer> property) {
+	}
+
+	@Override
+	public void visitEndOfLine(final ConfigProperty<EndOfLineOption> property) {
+		setPreference("org.eclipse.core.runtime", "line.separator", property.getValue().getEndOfLineString());
+	}
+
+	@Override
+	public void visitCharset(final ConfigProperty<String> property) {
+		setPreference("org.eclipse.core.resources", "encoding", property.getValue().toUpperCase());
+	}
+
+	@Override
+	public void visitTrimTrailingWhitespace(final ConfigProperty<Boolean> property) {
+		setPreference("org.eclipse.jdt.ui", "sp_cleanup.remove_trailing_whitespaces", property.getValue().toString());
+	}
+
+	@Override
+	public void visitInsertFinalNewLine(final ConfigProperty<Boolean> property) {
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing",
+				property.getValue().toString());
+	}
+
+}


### PR DESCRIPTION
@ncjones Please don't blindly merge this because I haven't ran added functional tests or installed and tested locally yet, I just wanted your initial thoughts.

Also, I can't get the functional tests to work locally (even without my changes), can they not be ran from Windows? When I run `mvn -f editorconfig-eclipse-functional-test/pom.xml integration-test` it opens an Eclipse window and just hangs for a while and then prints out a lot of tests failing with this output

```
Tests run: 8, Failures: 0, Errors: 8, Skipped: 0, Time elapsed: 45.319 sec <<< FAILURE! - in com.ncjones.editorconfig.eclipse.test.EditorConfigTest
testIndentStyleTab[test.xml](com.ncjones.editorconfig.eclipse.test.EditorConfigTest)  Time elapsed: 5.135 sec  <<< ERROR!
java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/code/external-projects/editorconfig-eclipse/editorconfig-eclipse-functional-test/target/work/data/\editorconfig-test\.project
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
        at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
        at java.nio.file.Paths.get(Paths.java:84)
        at com.ncjones.editorconfig.eclipse.test.EditorConfigTestContext.createJavaProjectIfNotExists(EditorConfigTestContext.java:68)
        at com.ncjones.editorconfig.eclipse.test.EditorConfigTestContext.<init>(EditorConfigTestContext.java:45)
        at com.ncjones.editorconfig.eclipse.test.EditorConfigTest.setUp(EditorConfigTest.java:55)
```