### PR TITLE
Adds tab_width feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Feature Support
 |----------------------------|---------|---------------------------------------------|
 | `indent_style`             | Yes     | tested with Java, XML, Ant and text editors |
 | `indent_size`              | Yes     | tested with Java, XML, Ant and text editors |
-| `tab_width`                | No      |                                             |
+| `tab_width`                | Yes     | tested with Java, XML, Ant and text editors |
 | `end_of_line`              | No      | applies to files created after similar file opened |
 | `charset`                  | Yes     | untested                                    |
 | `trim_trailing_whitespace` | No      |                                             |

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -44,14 +44,16 @@ public class EditorConfigVisitor implements ConfigPropertyVisitor {
 	@Override
 	public void visitIndentSize(final ConfigProperty<Integer> property) {
 		final String indentSizeString = property.getValue().toString();
-		setPreference("org.eclipse.ui.editors", "tabWidth", indentSizeString);
-		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", indentSizeString);
 		setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
-		setPreference("org.eclipse.ant.ui", "formatter_tab_size", indentSizeString);
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.indentation.size", indentSizeString);
 	}
 
 	@Override
 	public void visitTabWidth(final ConfigProperty<Integer> property) {
+		final String tabWidth = property.getValue().toString();
+		setPreference("org.eclipse.ui.editors", "tabWidth", tabWidth);
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", tabWidth);
+		setPreference("org.eclipse.ant.ui", "formatter_tab_size", tabWidth);
 	}
 
 	@Override


### PR DESCRIPTION
mapped tab_width with:

 - tabWidth (org.eclipse.ui.editors)
 - org.eclipse.jdt.core.formatter.tabulation.size (org.eclipse.jdt.core)
 - formatter_tab_size (org.eclipse.ant.ui)

mapped indent_size with:

 - indentationSize (org.eclipse.wst.xml.core)
 - org.eclipse.jdt.core.formatter.indentation.size (org.eclipse.jdt.core)