### PR TITLE
Fix xml editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Feature Support
 |----------------------------|---------|---------------------------------------------|
 | `indent_style`             | Yes     | tested with Java, XML, Ant and text editors |
 | `indent_size`              | Yes     | tested with Java, XML, Ant and text editors |
-| `tab_width`                | No      |                                             |
+| `tab_width`                | Yes     | tested with Java, XML, Ant and text editors |
 | `end_of_line`              | No      | applies to files created after similar file opened |
 | `charset`                  | Yes     | untested                                    |
 | `trim_trailing_whitespace` | No      |                                             |

--- a/editorconfig-eclipse-functional-test/src/main/java/com/ncjones/editorconfig/eclipse/test/EditorConfigTest.java
+++ b/editorconfig-eclipse-functional-test/src/main/java/com/ncjones/editorconfig/eclipse/test/EditorConfigTest.java
@@ -79,4 +79,16 @@ public class EditorConfigTest {
 		assertThat(context.fileContents(fileName), equalTo("\t"));
 	}
 
+	@Test
+	public void testIndentStyleTabWithSize() throws Exception {
+		context.editorConfig(
+			"root = true",
+			"[*]",
+			"indent_style = tab",
+			"indent_size = 2"
+		);
+		context.editFile(fileName, "\t");
+		assertThat(context.fileContents(fileName), equalTo("\t"));
+	}
+
 }

--- a/org.eclipse.editorconfig.core/build.properties
+++ b/org.eclipse.editorconfig.core/build.properties
@@ -1,5 +1,5 @@
 source.. = src/main/java/,\
-           editorconfig-core-java/src/
+           editorconfig-core-java/src/main/java
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigEditorActivationHandler.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigEditorActivationHandler.java
@@ -35,8 +35,9 @@ public class EditorConfigEditorActivationHandler implements EditorActivationHand
 		if (editorFile != null) {
 			final EditorFileConfig fileEditorConfig = getEditorFileConfig(editorFile);
 			System.out.println("Editor activated: " + fileEditorConfig);
+			EditorConfigVisitor visitor = new EditorConfigVisitor(fileEditorConfig);
 			for (final ConfigProperty<?> configProperty : fileEditorConfig.getConfigProperties()) {
-				configProperty.accept(new EditorConfigVisitor());
+				configProperty.accept(visitor);
 			}
 		}
 	}

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -21,10 +21,17 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.editorconfig.core.ConfigProperty;
 import org.eclipse.editorconfig.core.ConfigPropertyVisitor;
+import org.eclipse.editorconfig.core.EditorFileConfig;
 import org.eclipse.editorconfig.core.EndOfLineOption;
 import org.eclipse.editorconfig.core.IndentStyleOption;
 
 public class EditorConfigVisitor implements ConfigPropertyVisitor {
+
+	private final EditorFileConfig config;
+
+	public EditorConfigVisitor(EditorFileConfig config) {
+		this.config = config;
+	}
 
 	private void setPreference(final String prefsNodeName, final String key, final String value) {
 		System.out.println(String.format("Setting preference: %s/%s=%s", prefsNodeName, key, value));

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -44,14 +44,16 @@ public class EditorConfigVisitor implements ConfigPropertyVisitor {
 	@Override
 	public void visitIndentSize(final ConfigProperty<Integer> property) {
 		final String indentSizeString = property.getValue().toString();
-		setPreference("org.eclipse.ui.editors", "tabWidth", indentSizeString);
-		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", indentSizeString);
 		setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
-		setPreference("org.eclipse.ant.ui", "formatter_tab_size", indentSizeString);
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.indentation.size", indentSizeString);
 	}
 
 	@Override
 	public void visitTabWidth(final ConfigProperty<Integer> property) {
+		final String tabWidth = property.getValue().toString();
+		setPreference("org.eclipse.ui.editors", "tabWidth", tabWidth);
+		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", tabWidth);
+		setPreference("org.eclipse.ant.ui", "formatter_tab_size", tabWidth);
 	}
 
 	@Override

--- a/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
+++ b/org.eclipse.editorconfig.ui/src/main/java/org/eclipse/editorconfig/ui/internal/EditorConfigVisitor.java
@@ -20,6 +20,7 @@ package org.eclipse.editorconfig.ui.internal;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.editorconfig.core.ConfigProperty;
+import org.eclipse.editorconfig.core.ConfigPropertyType;
 import org.eclipse.editorconfig.core.ConfigPropertyVisitor;
 import org.eclipse.editorconfig.core.EditorFileConfig;
 import org.eclipse.editorconfig.core.EndOfLineOption;
@@ -51,13 +52,17 @@ public class EditorConfigVisitor implements ConfigPropertyVisitor {
 	@Override
 	public void visitIndentSize(final ConfigProperty<Integer> property) {
 		final String indentSizeString = property.getValue().toString();
-		setPreference("org.eclipse.wst.xml.core", "indentationSize", indentSizeString);
-		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.indentation.size", indentSizeString);
+		// this represents the number of tabs, not their width
+		setPreference("org.eclipse.wst.xml.core", "indentationSize",
+				config.getConfigProperty(ConfigPropertyType.INDENT_STYLE.getName()).getValue().equals(IndentStyleOption.SPACE)
+					? indentSizeString
+					: "1");
 	}
 
 	@Override
 	public void visitTabWidth(final ConfigProperty<Integer> property) {
 		final String tabWidth = property.getValue().toString();
+		// xml editor will follow this
 		setPreference("org.eclipse.ui.editors", "tabWidth", tabWidth);
 		setPreference("org.eclipse.jdt.core", "org.eclipse.jdt.core.formatter.tabulation.size", tabWidth);
 		setPreference("org.eclipse.ant.ui", "formatter_tab_size", tabWidth);


### PR DESCRIPTION
Closes #41 by setting xml editor indent size to 1 when using tabs.

This replaces #42 and I also cherry-picked the commit of #45. Si they can both be closed when this is merged.

I also used the latest version of editorconfig-core-java.

